### PR TITLE
ready for upboard test

### DIFF
--- a/sw/airborne/modules/spiking_landing/spiking_landing.c
+++ b/sw/airborne/modules/spiking_landing/spiking_landing.c
@@ -268,11 +268,6 @@ static void sl_run(float divergence, float divergence_dot) {
     first_run = false;
   }
 
-  // Send divergence to upboard over UART
-#ifdef SL_UART_CONTROL
-  uart_driver_tx_event(divergence, reset_flag);
-#endif
-
   // Let the vehicle settle
   if (get_sys_time_float() - start_time < 5.0f) {
     return;

--- a/sw/airborne/modules/uart_driver/uart_driver.h
+++ b/sw/airborne/modules/uart_driver/uart_driver.h
@@ -60,9 +60,8 @@ LOIHI LANDER - TX DIVERGENCE
 */
 
 typedef struct __attribute__((packed)) {
-  int cnt;
   float divergence;
-  float divergence_dot;
+  uint8_t reset_net;
 } divergence_frame_t;
 
 typedef struct __attribute__((packed)) {
@@ -75,7 +74,6 @@ LOIHI LANDER - RX THRUST
 */
 
 typedef struct __attribute__((packed)) {
-  int cnt;
   float thrust;
 } thrust_frame_t;
 
@@ -85,12 +83,10 @@ typedef struct __attribute__((packed)) {
 } thrust_packet_t;
 
 extern thrust_frame_t uart_rx_buffer;
-extern pthread_mutex_t* rx_mutex;
 
 extern void uart_driver_rx_event(void);
 extern void uart_driver_init(void);
-extern void uart_driver_tx_loop(void);
-extern void uart_driver_tx_event(float divergence, float divergence_dot);
+extern void uart_driver_tx_event(float divergence, uint8_t reset_net);
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
Note: 

When using the SNN in the upboard (see https://github.com/nilay994/tx2-peripherals/tree/master/uart_snn_demo), the scaling and bounding of the thrust value is done in the C++ code and not in paparazzi. I decided to do this to avoid potential race issues in the RX UART loop.